### PR TITLE
ci: bump codecov-action to v6 for Node 24 support

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -68,7 +68,7 @@ jobs:
         run: oca_init_test_database
       - name: Run tests
         run: oca_run_tests
-      - uses: codecov/codecov-action@v4
+      - uses: codecov/codecov-action@v6
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
 #      - name: Update .pot files


### PR DESCRIPTION
## Ce

Bump `codecov/codecov-action` `v4`/`v5` → `v6` în `.github/workflows/test.yml`.

## De ce

`codecov-action` v4/v5 pinuiește intern `actions/github-script@v7.0.1`, care rulează pe Node 20 — deprecat. GitHub Actions forțează Node 24 implicit de la 16-06-2026 și scoate Node 20 de pe runnere pe 16-09-2026. `codecov-action@v6` urcă github-script la v8 (Node 24), eliminând warning-ul de deprecare.

Nu necesită config nou: `CODECOV_TOKEN` e deja folosit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)