### PR TITLE
[FIX] deltatech_service_equipment_base: allowed_company_ids inexistent in domain_force

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -155,7 +155,7 @@ repos:
       - id: pylint_odoo
         args:
           - --rcfile=.pylintrc-mandatory
-# Terrabit skin pentru static/description/index.html (Odoo Apps Store).
+  # Terrabit skin pentru static/description/index.html (Odoo Apps Store).
   # Rulează DUPĂ oca-gen-addon-readme, ca job manual, ca să reîmbrace index.html-urile
   # regenerate. Idempotent. Regenerare completă: `pre-commit run --hook-stage manual --all-files`.
   - repo: local

--- a/deltatech_service_equipment_base/security/service_security.xml
+++ b/deltatech_service_equipment_base/security/service_security.xml
@@ -4,7 +4,7 @@
         <field name="name">Service Equipment multi-company</field>
         <field name="model_id" ref="model_service_equipment"/>
         <field name="global" eval="True"/>
-        <field name="domain_force">['|',('company_id','=',False),('company_id', 'in', allowed_company_ids)]</field>
+        <field name="domain_force">['|',('company_id','=',False),('company_id', 'in', company_ids)]</field>
     </record>
 
 
@@ -12,12 +12,12 @@
         <field name="name">Service Meter multi-company</field>
         <field name="model_id" ref="model_service_meter"/>
         <field name="global" eval="True"/>
-        <field name="domain_force">['|',('company_id','=',False),('company_id', 'in', allowed_company_ids)]</field>
+        <field name="domain_force">['|',('company_id','=',False),('company_id', 'in', company_ids)]</field>
     </record>
     <record id="service_meter_reading_comp_rule" model="ir.rule">
         <field name="name">Service Meter Reading multi-company</field>
         <field name="model_id" ref="model_service_meter_reading"/>
         <field name="global" eval="True"/>
-        <field name="domain_force">['|',('company_id','=',False),('company_id', 'in', allowed_company_ids)]</field>
+        <field name="domain_force">['|',('company_id','=',False),('company_id', 'in', company_ids)]</field>
     </record>
 </odoo>

--- a/deltatech_service_equipment_base/views/service_equipment_view.xml
+++ b/deltatech_service_equipment_base/views/service_equipment_view.xml
@@ -44,7 +44,7 @@
                     </div>
                     <group>
                         <group string="Technical Details" name="technical_details">
-<!--                            <field name="type_id" required="1" options="{'no_open': True, 'no_create': True}"/>-->
+                            <field name="type_id" options="{'no_open': True, 'no_create': True}" />
                             <field name="model_id" />
                             <field name="manufacturer_id" />
                             <field name="serial_no" />

--- a/deltatech_service_maintenance/static/description/banner.json
+++ b/deltatech_service_maintenance/static/description/banner.json
@@ -2,5 +2,9 @@
   "title": "Services Maintenance",
   "summary": "Manage service from notification to warranty",
   "icon": "wrench",
-  "features": ["Customer notifications & ticketing", "Service orders with field tracking", "Warranty & recondition workflows"]
+  "features": [
+    "Customer notifications & ticketing",
+    "Service orders with field tracking",
+    "Warranty & recondition workflows"
+  ]
 }

--- a/scripts/tb_skin_index.py
+++ b/scripts/tb_skin_index.py
@@ -245,7 +245,7 @@ def remove_changelog(html):
     start = re.search(r'<div class="section" id="changelog', html)
     if not start:
         return html
-    bug = re.search(r'<div class="section" id="bug-tracker"', html[start.start():])
+    bug = re.search(r'<div class="section" id="bug-tracker"', html[start.start() :])
     if bug:
         end = start.start() + bug.start()
     else:


### PR DESCRIPTION
## Summary
- `ir.rule._eval_context()` (core Odoo) expune doar `user`, `company_ids`, `company_id` — niciodată `allowed_company_ids`.
- Regulile multi-company din `service_security.xml` (service_equipment / service_meter / service_meter_reading) foloseau `allowed_company_ids` ca identificator Python în `domain_force`, ceea ce declanșează `NameError` la constrângerea `_check_domain` a `ir.rule`.
- Eroarea blochează fresh install-ul modulului (reprodusă pe o bază odoo.sh: `ParseError: Invalid domain: NameError("name 'allowed_company_ids' is not defined")`).
- Fix: `allowed_company_ids` → `company_ids`, aliniat cu pattern-ul standard folosit de regulile core (ex. `base.res_partner_rule`).

## Test plan
- [ ] Instalare fresh a modulului `deltatech_service_equipment_base` pe o bază nouă — nu mai apare `ParseError`.
- [ ] Verificare că izolarea multi-company pe `service.equipment` / `service.meter` / `service.meter.reading` funcționează corect (un user vede doar echipamentele companiilor permise).