### PR TITLE
[FIX] service meter: restore read_by column in reading list view

### DIFF
--- a/deltatech_service_equipment_base/views/service_meter_view.xml
+++ b/deltatech_service_equipment_base/views/service_meter_view.xml
@@ -120,6 +120,7 @@
                 <field name="counter_value"/>
                 <field name="difference"/>
                 <field name="estimated"/>
+                <field name="read_by" optional="show"/>
             </list>
         </field>
     </record>


### PR DESCRIPTION
## Context
Aliniere funcțională 18.0 → 19.0 pentru `deltatech_service_equipment_base` și `deltatech_service_task`.

Ambele module erau deja pe 19.0. Singurul drift găsit: câmpul **`read_by`** lipsea din list view-ul de citiri contor (`view_service_meter_reading_tree` pe `service.meter.reading`) — exista doar în form view. Regresie apărută la migrarea 18→19.

## Modificare
Restaurat câmpul în list view (recuperat din 18.0, commit `00d0d21`):
```xml
<field name="read_by" optional="show"/>
```

`deltatech_service_task` — verificat, fără drift/regresie, nicio modificare necesară.

🤖 Generated with [Claude Code](https://claude.com/claude-code)