### PR TITLE
[IMP] deltatech_service_equipment: traducere RO

### DIFF
--- a/deltatech_service_equipment/i18n/ro.po
+++ b/deltatech_service_equipment/i18n/ro.po
@@ -1,0 +1,911 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* deltatech_service_equipment
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 19.0+e\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-07-30 07:52+0000\n"
+"PO-Revision-Date: 2026-07-30 07:52+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"Language: ro\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: deltatech_service_equipment
+#: model_terms:ir.ui.view,arch_db:deltatech_service_equipment.view_service_agreement_form
+#: model_terms:ir.ui.view,arch_db:deltatech_service_equipment.view_service_equipment_form
+msgid "<span class=\"o_stat_text\">History Place</span>"
+msgstr "<span class=\"o_stat_text\">Istoric amplasare</span>"
+
+#. module: deltatech_service_equipment
+#: model_terms:ir.ui.view,arch_db:deltatech_service_equipment.view_service_equipment_form
+msgid "<span class=\"o_stat_text\">Invoiced</span>"
+msgstr "<span class=\"o_stat_text\">Facturat</span>"
+
+#. module: deltatech_service_equipment
+#: model_terms:ir.ui.view,arch_db:deltatech_service_equipment.view_service_equipment_form
+msgid "<span class=\"o_stat_text\">Meters</span>"
+msgstr "<span class=\"o_stat_text\">Contori</span>"
+
+#. module: deltatech_service_equipment
+#: model_terms:ir.ui.view,arch_db:deltatech_service_equipment.view_service_equipment_form
+msgid "<span class=\"o_stat_text\">Revenues</span>"
+msgstr "<span class=\"o_stat_text\">Venituri</span>"
+
+#. module: deltatech_service_equipment
+#: model_terms:ir.ui.view,arch_db:deltatech_service_equipment.view_service_equipment_form
+msgid "Add Readings"
+msgstr "Adaugă citiri"
+
+#. module: deltatech_service_equipment
+#: model:ir.actions.act_window,name:deltatech_service_equipment.action_service_equi_add
+#: model:ir.model.fields.selection,name:deltatech_service_equipment.selection__service_equi_operation__state__add
+#: model_terms:ir.ui.view,arch_db:deltatech_service_equipment.view_service_equipment_form
+msgid "Add to Agreement"
+msgstr "Adaugă la contract"
+
+#. module: deltatech_service_equipment
+#. odoo-python
+#: code:addons/deltatech_service_equipment/wizard/service_equi_operation.py:0
+msgid "Add to contract"
+msgstr "Adaugă la contract"
+
+#. module: deltatech_service_equipment
+#. odoo-python
+#: code:addons/deltatech_service_equipment/wizard/service_equi_operation.py:0
+msgid ""
+"Add to contract %(agreement_name)s, partner %(partner_name)s, address "
+"%(address_name)s, emplacement %(emplacement)s."
+msgstr ""
+"Adăugare la contractul %(agreement_name)s, partener %(partner_name)s, adresă"
+" %(address_name)s, amplasament %(emplacement)s."
+
+#. module: deltatech_service_equipment
+#: model:ir.model.fields,field_description:deltatech_service_equipment.field_service_equipment__address_id
+msgid "Address"
+msgstr "Adresă"
+
+#. module: deltatech_service_equipment
+#: model_terms:ir.ui.view,arch_db:deltatech_service_equipment.service_history_search
+msgid "Agreement"
+msgstr "Contract"
+
+#. module: deltatech_service_equipment
+#: model:ir.model.fields,field_description:deltatech_service_equipment.field_service_agreement__common_history_ids
+msgid "Agreement History"
+msgstr "Istoric contracte"
+
+#. module: deltatech_service_equipment
+#: model:ir.model.fields,field_description:deltatech_service_equipment.field_service_equipment__agreement_type_id
+msgid "Agreement Type"
+msgstr "Tip acrod"
+
+#. module: deltatech_service_equipment
+#: model:ir.model.constraint,message:deltatech_service_equipment.constraint_service_consumption_agreement_line_period_uniq
+msgid "Agreement line in period already exist!"
+msgstr "Există deja o linie de contract în această perioadă!"
+
+#. module: deltatech_service_equipment
+#. odoo-python
+#: code:addons/deltatech_service_equipment/models/account_move.py:0
+msgid "Agreement: %(agreement_details)s "
+msgstr "Contract: %(agreement_details)s "
+
+#. module: deltatech_service_equipment
+#: model:ir.model.fields,field_description:deltatech_service_equipment.field_service_agreement_type__permits_pickings
+msgid "Allows non-billable deliveries"
+msgstr "Permite livrări nefacturabile"
+
+#. module: deltatech_service_equipment
+#: model:ir.model.fields,field_description:deltatech_service_equipment.field_service_equipment__analytic_account_id
+msgid "Analytic"
+msgstr "Analitic"
+
+#. module: deltatech_service_equipment
+#: model_terms:ir.ui.view,arch_db:deltatech_service_equipment.view_service_equi_operation_form
+msgid "Apply"
+msgstr "Aplică"
+
+#. module: deltatech_service_equipment
+#: model:ir.model.fields.selection,name:deltatech_service_equipment.selection__service_equipment__state__available
+msgid "Available"
+msgstr "Disponibil"
+
+#. module: deltatech_service_equipment
+#: model:ir.model.fields.selection,name:deltatech_service_equipment.selection__service_equipment__state__backuped
+msgid "Backuped"
+msgstr "De rezervă"
+
+#. module: deltatech_service_equipment
+#: model:ir.model.fields,field_description:deltatech_service_equipment.field_service_meter_category__bill_uom_id
+#: model:ir.model.fields,field_description:deltatech_service_equipment.field_service_template_meter__bill_uom_id
+msgid "Billing Unit of Measure"
+msgstr "Unitate de măsură pentru facturare"
+
+#. module: deltatech_service_equipment
+#: model:ir.model.fields,field_description:deltatech_service_equipment.field_service_equi_operation__can_remove
+msgid "Can Remove"
+msgstr "Poate fi eliminat"
+
+#. module: deltatech_service_equipment
+#: model:res.groups,name:deltatech_service_equipment.force_agreement_invoice
+msgid "Can bill without meter readings"
+msgstr "Poate factura fără citiri de contor"
+
+#. module: deltatech_service_equipment
+#: model_terms:ir.ui.view,arch_db:deltatech_service_equipment.view_service_equi_operation_form
+msgid "Cancel"
+msgstr "Anulează"
+
+#. module: deltatech_service_equipment
+#: model:ir.model.fields,field_description:deltatech_service_equipment.field_service_equipment_type__categ_id
+#: model:ir.model.fields,field_description:deltatech_service_equipment.field_service_template_meter__categ_id
+msgid "Category"
+msgstr "Categorie"
+
+#. module: deltatech_service_equipment
+#: model:mail.message.subtype,name:deltatech_service_equipment.mt_equipment_change_status
+msgid "Change status"
+msgstr "Schimbă starea"
+
+#. module: deltatech_service_equipment
+#: model:ir.model.fields,field_description:deltatech_service_equipment.field_service_template_meter__company_id
+msgid "Company"
+msgstr "Companie"
+
+#. module: deltatech_service_equipment
+#: model:ir.model,name:deltatech_service_equipment.model_res_config_settings
+msgid "Config Settings"
+msgstr "Setări de configurare"
+
+#. module: deltatech_service_equipment
+#: model:ir.model.fields,field_description:deltatech_service_equipment.field_service_meter_reading__consumption_id
+msgid "Consumption"
+msgstr "Consum"
+
+#. module: deltatech_service_equipment
+#: model:ir.model.fields,field_description:deltatech_service_equipment.field_service_equi_operation__agreement_id
+#: model:ir.model.fields,field_description:deltatech_service_equipment.field_service_equipment__agreement_id
+msgid "Contract Service"
+msgstr "Contract servicii"
+
+#. module: deltatech_service_equipment
+#: model_terms:ir.ui.view,arch_db:deltatech_service_equipment.view_service_equipment_form
+msgid "Create Meters"
+msgstr "Creează contori"
+
+#. module: deltatech_service_equipment
+#: model:ir.model.fields,field_description:deltatech_service_equipment.field_service_equi_operation__create_uid
+#: model:ir.model.fields,field_description:deltatech_service_equipment.field_service_history__create_uid
+msgid "Created by"
+msgstr "Creat de"
+
+#. module: deltatech_service_equipment
+#: model:ir.model.fields,field_description:deltatech_service_equipment.field_service_equi_operation__create_date
+#: model:ir.model.fields,field_description:deltatech_service_equipment.field_service_history__create_date
+msgid "Created on"
+msgstr "Creat pe"
+
+#. module: deltatech_service_equipment
+#: model:ir.model.fields,field_description:deltatech_service_equipment.field_service_template_meter__currency_id
+msgid "Currency"
+msgstr "Moneda"
+
+#. module: deltatech_service_equipment
+#: model:ir.model.fields,field_description:deltatech_service_equipment.field_service_equi_operation__partner_id
+#: model:ir.model.fields,field_description:deltatech_service_equipment.field_service_equipment__partner_id
+#: model:ir.model.fields.selection,name:deltatech_service_equipment.selection__service_equipment__location_type__customer
+msgid "Customer"
+msgstr "Client"
+
+#. module: deltatech_service_equipment
+#. odoo-python
+#: code:addons/deltatech_service_equipment/models/account_move.py:0
+msgid "Customer: %(customer_name)s"
+msgstr "Client: %(customer_name)s"
+
+#. module: deltatech_service_equipment
+#. odoo-python
+#: code:addons/deltatech_service_equipment/models/account_move.py:0
+#: model_terms:ir.ui.view,arch_db:deltatech_service_equipment.service_history_search
+msgid "Data"
+msgstr "Date"
+
+#. module: deltatech_service_equipment
+#: model:ir.model.fields,field_description:deltatech_service_equipment.field_service_equi_operation__date
+#: model:ir.model.fields,field_description:deltatech_service_equipment.field_service_history__date
+msgid "Date"
+msgstr "Data"
+
+#. module: deltatech_service_equipment
+#: model:ir.model.fields,help:deltatech_service_equipment.field_service_equipment__reading_day
+msgid ""
+"Day of the month, set -1 for the last day of the month.\n"
+"                                     If it's positive, it gives the day of the month. Set 0 for net days ."
+msgstr ""
+"Ziua din lună; setați -1 pentru ultima zi a lunii.\n"
+"                                     Dacă este pozitivă, indică ziua din lună. Setați 0 pentru zile nete ."
+
+#. module: deltatech_service_equipment
+#: model:ir.model.fields,field_description:deltatech_service_equipment.field_service_history__description
+msgid "Description"
+msgstr "Descriere"
+
+#. module: deltatech_service_equipment
+#: model:ir.model.fields,help:deltatech_service_equipment.field_service_equipment__emplacement
+msgid "Detail of location of the equipment in working point"
+msgstr "Detaliu privind amplasarea echipamentului în punctul de lucru"
+
+#. module: deltatech_service_equipment
+#. odoo-python
+#: code:addons/deltatech_service_equipment/models/account_move.py:0
+msgid "Difference"
+msgstr "Diferență"
+
+#. module: deltatech_service_equipment
+#: model:ir.model.fields,field_description:deltatech_service_equipment.field_account_move__display_name
+#: model:ir.model.fields,field_description:deltatech_service_equipment.field_product_category__display_name
+#: model:ir.model.fields,field_description:deltatech_service_equipment.field_product_template__display_name
+#: model:ir.model.fields,field_description:deltatech_service_equipment.field_res_config_settings__display_name
+#: model:ir.model.fields,field_description:deltatech_service_equipment.field_service_agreement__display_name
+#: model:ir.model.fields,field_description:deltatech_service_equipment.field_service_agreement_line__display_name
+#: model:ir.model.fields,field_description:deltatech_service_equipment.field_service_agreement_type__display_name
+#: model:ir.model.fields,field_description:deltatech_service_equipment.field_service_billing_preparation__display_name
+#: model:ir.model.fields,field_description:deltatech_service_equipment.field_service_consumption__display_name
+#: model:ir.model.fields,field_description:deltatech_service_equipment.field_service_equi_operation__display_name
+#: model:ir.model.fields,field_description:deltatech_service_equipment.field_service_equipment__display_name
+#: model:ir.model.fields,field_description:deltatech_service_equipment.field_service_equipment_category__display_name
+#: model:ir.model.fields,field_description:deltatech_service_equipment.field_service_equipment_type__display_name
+#: model:ir.model.fields,field_description:deltatech_service_equipment.field_service_history__display_name
+#: model:ir.model.fields,field_description:deltatech_service_equipment.field_service_meter_category__display_name
+#: model:ir.model.fields,field_description:deltatech_service_equipment.field_service_meter_reading__display_name
+#: model:ir.model.fields,field_description:deltatech_service_equipment.field_service_template_meter__display_name
+#: model:ir.model.fields,field_description:deltatech_service_equipment.field_stock_location__display_name
+#: model:ir.model.fields,field_description:deltatech_service_equipment.field_stock_lot__display_name
+msgid "Display Name"
+msgstr "Nume afișat"
+
+#. module: deltatech_service_equipment
+#: model:ir.model.fields.selection,name:deltatech_service_equipment.selection__service_equipment__readings_status__done
+msgid "Done"
+msgstr "Efectuate"
+
+#. module: deltatech_service_equipment
+#: model:ir.model.fields,field_description:deltatech_service_equipment.field_service_equipment__ean_code
+msgid "EAN Code"
+msgstr "Cod EAN"
+
+#. module: deltatech_service_equipment
+#: model:ir.model.constraint,message:deltatech_service_equipment.constraint_service_equipment_ean_code_uniq
+msgid "EAN Code already exist!"
+msgstr "Codul EAN există deja!"
+
+#. module: deltatech_service_equipment
+#: model:ir.model.fields,field_description:deltatech_service_equipment.field_service_equi_operation__emplacement
+#: model:ir.model.fields,field_description:deltatech_service_equipment.field_service_equipment__emplacement
+msgid "Emplacement"
+msgstr "Amplasament"
+
+#. module: deltatech_service_equipment
+#: model:ir.model.fields,field_description:deltatech_service_equipment.field_service_equi_operation__enter_reading_id
+msgid "Enter Reading"
+msgstr "Introducere citire"
+
+#. module: deltatech_service_equipment
+#. odoo-python
+#: code:addons/deltatech_service_equipment/models/account_move.py:0
+#: model:ir.model.fields,field_description:deltatech_service_equipment.field_service_agreement_line__equipment_id
+#: model:ir.model.fields,field_description:deltatech_service_equipment.field_service_consumption__equipment_id
+#: model:ir.model.fields,field_description:deltatech_service_equipment.field_service_equi_operation__equipment_id
+#: model:ir.model.fields,field_description:deltatech_service_equipment.field_service_history__equipment_id
+#: model:ir.model.fields.selection,name:deltatech_service_equipment.selection__service_equipment__internal_type__equipment
+#: model_terms:ir.ui.view,arch_db:deltatech_service_equipment.service_history_search
+#: model_terms:ir.ui.view,arch_db:deltatech_service_equipment.view_category_form_equi
+msgid "Equipment"
+msgstr "Echipament"
+
+#. module: deltatech_service_equipment
+#: model:ir.model.fields,field_description:deltatech_service_equipment.field_service_agreement__equipment_count
+msgid "Equipment Count"
+msgstr "Număr de echipamente"
+
+#. module: deltatech_service_equipment
+#: model:ir.model.fields,field_description:deltatech_service_equipment.field_service_equipment__common_history_ids
+msgid "Equipment History"
+msgstr "Istoric echipament"
+
+#. module: deltatech_service_equipment
+#: model:mail.message.subtype,description:deltatech_service_equipment.mt_equipment_change_status
+msgid "Equipment change status"
+msgstr "Schimbare stare echipament"
+
+#. module: deltatech_service_equipment
+#. odoo-python
+#: code:addons/deltatech_service_equipment/wizard/service_equi_operation.py:0
+msgid ""
+"Equipment installation at %(partner_name)s, address %(address_name)s, emplacement %(emplacement)s.\r"
+"\r"
+"Meters: %(counters)s"
+msgstr ""
+"Instalare echipament la %(partner_name)s, adresă %(address_name)s, amplasament %(emplacement)s.\r\n"
+"Contori: %(counters)s"
+
+#. module: deltatech_service_equipment
+#: model:ir.model.fields,field_description:deltatech_service_equipment.field_product_product__equi_type_id
+#: model:ir.model.fields,field_description:deltatech_service_equipment.field_product_template__equi_type_id
+msgid "Equipment type"
+msgstr "Tip echipament"
+
+#. module: deltatech_service_equipment
+#: model:ir.model.fields,field_description:deltatech_service_equipment.field_product_category__equi_type_required
+#: model:ir.model.fields,field_description:deltatech_service_equipment.field_product_product__equi_type_required
+#: model:ir.model.fields,field_description:deltatech_service_equipment.field_product_template__equi_type_required
+msgid "Equipment type required"
+msgstr "Tipul de echipament este obligatoriu"
+
+#. module: deltatech_service_equipment
+#: model_terms:ir.ui.view,arch_db:deltatech_service_equipment.view_service_agreement_form
+msgid "Equipments"
+msgstr "Echipamente"
+
+#. module: deltatech_service_equipment
+#: model:ir.model.fields,field_description:deltatech_service_equipment.field_service_equi_operation__error
+msgid "Error"
+msgstr "Eroare"
+
+#. module: deltatech_service_equipment
+#: model_terms:ir.ui.view,arch_db:deltatech_service_equipment.view_move_form
+msgid "Export meters XLS"
+msgstr "Exportă contorii în XLS"
+
+#. module: deltatech_service_equipment
+#: model:ir.actions.act_window,name:deltatech_service_equipment.service_history_action
+msgid "History"
+msgstr "Istoric"
+
+#. module: deltatech_service_equipment
+#: model:ir.ui.menu,name:deltatech_service_equipment.service_history_menu
+msgid "History Equipment/Agreement"
+msgstr "Istoric echipament/contract"
+
+#. module: deltatech_service_equipment
+#: model:ir.model.fields,field_description:deltatech_service_equipment.field_account_move__id
+#: model:ir.model.fields,field_description:deltatech_service_equipment.field_product_category__id
+#: model:ir.model.fields,field_description:deltatech_service_equipment.field_product_template__id
+#: model:ir.model.fields,field_description:deltatech_service_equipment.field_res_config_settings__id
+#: model:ir.model.fields,field_description:deltatech_service_equipment.field_service_agreement__id
+#: model:ir.model.fields,field_description:deltatech_service_equipment.field_service_agreement_line__id
+#: model:ir.model.fields,field_description:deltatech_service_equipment.field_service_agreement_type__id
+#: model:ir.model.fields,field_description:deltatech_service_equipment.field_service_billing_preparation__id
+#: model:ir.model.fields,field_description:deltatech_service_equipment.field_service_consumption__id
+#: model:ir.model.fields,field_description:deltatech_service_equipment.field_service_equi_operation__id
+#: model:ir.model.fields,field_description:deltatech_service_equipment.field_service_equipment__id
+#: model:ir.model.fields,field_description:deltatech_service_equipment.field_service_equipment_category__id
+#: model:ir.model.fields,field_description:deltatech_service_equipment.field_service_equipment_type__id
+#: model:ir.model.fields,field_description:deltatech_service_equipment.field_service_history__id
+#: model:ir.model.fields,field_description:deltatech_service_equipment.field_service_meter_category__id
+#: model:ir.model.fields,field_description:deltatech_service_equipment.field_service_meter_reading__id
+#: model:ir.model.fields,field_description:deltatech_service_equipment.field_service_template_meter__id
+#: model:ir.model.fields,field_description:deltatech_service_equipment.field_stock_location__id
+#: model:ir.model.fields,field_description:deltatech_service_equipment.field_stock_lot__id
+msgid "ID"
+msgstr "ID"
+
+#. module: deltatech_service_equipment
+#: model:ir.model.fields.selection,name:deltatech_service_equipment.selection__service_equipment__location_type__stock
+msgid "In Stock"
+msgstr "În stoc"
+
+#. module: deltatech_service_equipment
+#: model:ir.model.fields.selection,name:deltatech_service_equipment.selection__service_equipment__state__installing
+msgid "In installing"
+msgstr "În instalare"
+
+#. module: deltatech_service_equipment
+#: model:ir.model.fields.selection,name:deltatech_service_equipment.selection__service_equipment__location_type__rental
+msgid "In rental"
+msgstr "În chirie"
+
+#. module: deltatech_service_equipment
+#: model:ir.model.fields.selection,name:deltatech_service_equipment.selection__service_equipment__state__inactive
+msgid "Inactive"
+msgstr "Inactiv"
+
+#. module: deltatech_service_equipment
+#: model_terms:ir.ui.view,arch_db:deltatech_service_equipment.view_service_equipment_form
+msgid "Install"
+msgstr "Instalare"
+
+#. module: deltatech_service_equipment
+#. odoo-python
+#: code:addons/deltatech_service_equipment/wizard/service_equi_operation.py:0
+#: model:ir.actions.act_window,name:deltatech_service_equipment.action_service_equi_ins
+#: model:ir.model.fields.selection,name:deltatech_service_equipment.selection__service_equi_operation__state__ins
+msgid "Installation"
+msgstr "Instalare"
+
+#. module: deltatech_service_equipment
+#: model:ir.model.fields,field_description:deltatech_service_equipment.field_service_equipment__installation_date
+msgid "Installation Date"
+msgstr "Data instalării"
+
+#. module: deltatech_service_equipment
+#: model:ir.model.fields.selection,name:deltatech_service_equipment.selection__service_equipment__state__installed
+msgid "Installed"
+msgstr "Instalat"
+
+#. module: deltatech_service_equipment
+#. odoo-python
+#: code:addons/deltatech_service_equipment/models/account_move.py:0
+msgid "Installed at"
+msgstr "Instalat la"
+
+#. module: deltatech_service_equipment
+#: model:ir.model.fields,field_description:deltatech_service_equipment.field_service_equipment__internal_type
+msgid "Internal Type"
+msgstr "Tip intern"
+
+#. module: deltatech_service_equipment
+#: model:ir.model,name:deltatech_service_equipment.model_stock_location
+msgid "Inventory Locations"
+msgstr "Locații inventar"
+
+#. module: deltatech_service_equipment
+#. odoo-python
+#: code:addons/deltatech_service_equipment/models/account_move.py:0
+msgid "Invoice: %(invoice_name)s / %(invoice_date)s"
+msgstr "Factura: %(invoice_name)s / %(invoice_date)s"
+
+#. module: deltatech_service_equipment
+#: model_terms:ir.ui.view,arch_db:deltatech_service_equipment.view_service_equipment_form
+msgid "Invoiced"
+msgstr "Facturat"
+
+#. module: deltatech_service_equipment
+#: model:ir.model.fields,field_description:deltatech_service_equipment.field_service_equi_operation__items
+msgid "Items"
+msgstr "Poziții"
+
+#. module: deltatech_service_equipment
+#: model:ir.model,name:deltatech_service_equipment.model_account_move
+msgid "Journal Entry"
+msgstr "Notă contabilă"
+
+#. module: deltatech_service_equipment
+#: model:ir.model.fields,field_description:deltatech_service_equipment.field_service_equipment__last_reading
+msgid "Last Reading Date"
+msgstr "Data ultimei citiri"
+
+#. module: deltatech_service_equipment
+#: model:ir.model.fields,field_description:deltatech_service_equipment.field_service_equi_operation__write_uid
+#: model:ir.model.fields,field_description:deltatech_service_equipment.field_service_history__write_uid
+msgid "Last Updated by"
+msgstr "Ultima actualizare de"
+
+#. module: deltatech_service_equipment
+#: model:ir.model.fields,field_description:deltatech_service_equipment.field_service_equi_operation__write_date
+#: model:ir.model.fields,field_description:deltatech_service_equipment.field_service_history__write_date
+msgid "Last Updated on"
+msgstr "Ultima actualizare pe"
+
+#. module: deltatech_service_equipment
+#: model:ir.model.fields,field_description:deltatech_service_equipment.field_service_equipment__last_reading_value
+msgid "Last reading value"
+msgstr "Valoarea ultimei citiri"
+
+#. module: deltatech_service_equipment
+#: model:ir.model.fields,field_description:deltatech_service_equipment.field_service_equi_operation__address_id
+#: model:ir.model.fields,field_description:deltatech_service_equipment.field_service_meter_reading__address_id
+#: model_terms:ir.ui.view,arch_db:deltatech_service_equipment.view_service_equi_operation_form
+#: model_terms:ir.ui.view,arch_db:deltatech_service_equipment.view_service_equipment_filter
+msgid "Location"
+msgstr "Locație"
+
+#. module: deltatech_service_equipment
+#: model:ir.model.fields,field_description:deltatech_service_equipment.field_service_equipment__location_type
+msgid "Location Type"
+msgstr "Tip Locație"
+
+#. module: deltatech_service_equipment
+#: model:ir.model,name:deltatech_service_equipment.model_stock_lot
+msgid "Lot/Serial"
+msgstr "Lot/Serie"
+
+#. module: deltatech_service_equipment
+#. odoo-python
+#: code:addons/deltatech_service_equipment/models/account_move.py:0
+#: model:ir.model.fields,field_description:deltatech_service_equipment.field_service_agreement_line__meter_id
+msgid "Meter"
+msgstr "Contor"
+
+#. module: deltatech_service_equipment
+#: model:ir.model,name:deltatech_service_equipment.model_service_meter_reading
+msgid "Meter Reading"
+msgstr "Citiri contori"
+
+#. module: deltatech_service_equipment
+#. odoo-python
+#: code:addons/deltatech_service_equipment/models/service_meter.py:0
+msgid "Meter reading recorder in consumption prepared for billing."
+msgstr ""
+"Citirea de contor a fost înregistrată în consumul pregătit pentru facturare."
+
+#. module: deltatech_service_equipment
+#: model:ir.model.fields,field_description:deltatech_service_equipment.field_service_equipment_type__template_meter_ids
+msgid "Meters"
+msgstr "Contori"
+
+#. module: deltatech_service_equipment
+#. odoo-python
+#: code:addons/deltatech_service_equipment/wizard/service_equi_operation.py:0
+msgid "Meters: %(counters)s"
+msgstr "Contori: %(counters)s"
+
+#. module: deltatech_service_equipment
+#: model:ir.model.fields.selection,name:deltatech_service_equipment.selection__service_equipment__readings_status__
+msgid "N/A"
+msgstr "N/A"
+
+#. module: deltatech_service_equipment
+#: model:ir.model.fields,field_description:deltatech_service_equipment.field_service_history__name
+msgid "Name"
+msgstr "Nume"
+
+#. module: deltatech_service_equipment
+#: model:ir.model.fields,field_description:deltatech_service_equipment.field_service_equipment__next_reading
+msgid "Next reading date"
+msgstr "Data următoarei citiri"
+
+#. module: deltatech_service_equipment
+#. odoo-python
+#: code:addons/deltatech_service_equipment/wizard/service_equi_operation.py:0
+msgid "No meter template defined for this equipment type."
+msgstr "Nu există un șablon de contor definit pentru acest tip de echipament."
+
+#. module: deltatech_service_equipment
+#: model:ir.model.fields,field_description:deltatech_service_equipment.field_service_equi_operation__note
+msgid "Notes"
+msgstr "Observații"
+
+#. module: deltatech_service_equipment
+#. odoo-python
+#: code:addons/deltatech_service_equipment/models/service_agreement.py:0
+msgid "Old index: %(old_index)s, New index:%(new_index)s"
+msgstr "Index vechi: %(old_index)s, Index nou:%(new_index)s"
+
+#. module: deltatech_service_equipment
+#: model:ir.model.fields,field_description:deltatech_service_equipment.field_service_equi_operation__state
+#: model_terms:ir.ui.view,arch_db:deltatech_service_equipment.view_service_equi_operation_form
+msgid "Operation"
+msgstr "Operație"
+
+#. module: deltatech_service_equipment
+#: model:ir.model.fields,field_description:deltatech_service_equipment.field_res_config_settings__picking_type_for_service
+msgid "Outgoing not to be invoiced"
+msgstr "Ieșire nefacturabilă"
+
+#. module: deltatech_service_equipment
+#: model:ir.model.fields,field_description:deltatech_service_equipment.field_service_equi_operation__service_period_id
+msgid "Period"
+msgstr "Perioadă"
+
+#. module: deltatech_service_equipment
+#: model_terms:ir.ui.view,arch_db:deltatech_service_equipment.res_config_settings_view_form_stock
+msgid "Picking type outgoing for service (not to be invoiced)."
+msgstr "Tip operație de ieșire pentru service (nefacturabilă)."
+
+#. module: deltatech_service_equipment
+#. odoo-python
+#: code:addons/deltatech_service_equipment/wizard/service_equi_operation.py:0
+msgid "Please select equipment."
+msgstr "Selectați echipamentul."
+
+#. module: deltatech_service_equipment
+#. odoo-python
+#: code:addons/deltatech_service_equipment/models/account_move.py:0
+msgid "Previous value"
+msgstr "Valoarea anterioară"
+
+#. module: deltatech_service_equipment
+#: model:ir.model,name:deltatech_service_equipment.model_product_template
+msgid "Product"
+msgstr "Produs"
+
+#. module: deltatech_service_equipment
+#: model:ir.model,name:deltatech_service_equipment.model_product_category
+msgid "Product Category"
+msgstr "Categorie produs"
+
+#. module: deltatech_service_equipment
+#: model:ir.model.fields,field_description:deltatech_service_equipment.field_service_equi_operation__read_by
+msgid "Read by"
+msgstr "Citită de"
+
+#. module: deltatech_service_equipment
+#. odoo-python
+#: code:addons/deltatech_service_equipment/models/account_move.py:0
+msgid "Read value"
+msgstr "Valoare citită"
+
+#. module: deltatech_service_equipment
+#: model:ir.model.fields,field_description:deltatech_service_equipment.field_service_equipment__reading_day
+msgid "Reading Day"
+msgstr "Ziua de citire"
+
+#. module: deltatech_service_equipment
+#: model_terms:ir.ui.view,arch_db:deltatech_service_equipment.view_service_equi_operation_form
+msgid "Readings"
+msgstr "Citiri"
+
+#. module: deltatech_service_equipment
+#: model:ir.model.fields,field_description:deltatech_service_equipment.field_service_equipment__readings_status
+msgid "Readings Status"
+msgstr "Stare citiri"
+
+#. module: deltatech_service_equipment
+#: model:ir.model.fields,field_description:deltatech_service_equipment.field_service_agreement__meter_reading_status
+#: model_terms:ir.ui.view,arch_db:deltatech_service_equipment.view_service_agreement_filter
+msgid "Readings done"
+msgstr "Citiri efectuate"
+
+#. module: deltatech_service_equipment
+#: model:ir.model.fields,field_description:deltatech_service_equipment.field_service_equipment__location_state_id
+#: model_terms:ir.ui.view,arch_db:deltatech_service_equipment.view_service_equipment_filter
+msgid "Region"
+msgstr "Județ"
+
+#. module: deltatech_service_equipment
+#: model:ir.actions.act_window,name:deltatech_service_equipment.action_service_equi_rem
+#: model:ir.model.fields.selection,name:deltatech_service_equipment.selection__service_equi_operation__state__rem
+msgid "Removal"
+msgstr "Ştergere"
+
+#. module: deltatech_service_equipment
+#: model_terms:ir.ui.view,arch_db:deltatech_service_equipment.view_service_equi_operation_form
+msgid "Remove"
+msgstr "Elimină"
+
+#. module: deltatech_service_equipment
+#: model_terms:ir.ui.view,arch_db:deltatech_service_equipment.view_service_equipment_form
+msgid "Remove from Agreement"
+msgstr "Elimină din contract"
+
+#. module: deltatech_service_equipment
+#: model:ir.model.fields,field_description:deltatech_service_equipment.field_stock_location__rental
+msgid "Rental"
+msgstr "Închiriere"
+
+#. module: deltatech_service_equipment
+#: model:ir.model.fields,field_description:deltatech_service_equipment.field_service_agreement_type__readings_required
+msgid "Requires readings for billing"
+msgstr "Necesită citiri pentru facturare"
+
+#. module: deltatech_service_equipment
+#: model_terms:ir.ui.view,arch_db:deltatech_service_equipment.view_service_equipment_form
+msgid "Revenues"
+msgstr "Venituri"
+
+#. module: deltatech_service_equipment
+#. odoo-python
+#: code:addons/deltatech_service_equipment/models/account_move.py:0
+msgid "Serial"
+msgstr "Serial"
+
+#. module: deltatech_service_equipment
+#. odoo-python
+#: code:addons/deltatech_service_equipment/wizard/service_equi_operation.py:0
+#: model:ir.model,name:deltatech_service_equipment.model_service_agreement
+#: model:ir.model.fields,field_description:deltatech_service_equipment.field_service_history__agreement_id
+msgid "Service Agreement"
+msgstr "Contract"
+
+#. module: deltatech_service_equipment
+#: model:ir.model,name:deltatech_service_equipment.model_service_agreement_line
+msgid "Service Agreement Line"
+msgstr "Linie contract servicii"
+
+#. module: deltatech_service_equipment
+#: model:ir.model,name:deltatech_service_equipment.model_service_agreement_type
+msgid "Service Agreement Type"
+msgstr "Tip contract"
+
+#. module: deltatech_service_equipment
+#: model:ir.model,name:deltatech_service_equipment.model_service_billing_preparation
+msgid "Service Billing Preparation"
+msgstr "Pregătire facturare service"
+
+#. module: deltatech_service_equipment
+#: model:ir.model,name:deltatech_service_equipment.model_service_equipment
+msgid "Service Equipment"
+msgstr "Echipament"
+
+#. module: deltatech_service_equipment
+#: model:ir.model,name:deltatech_service_equipment.model_service_equi_operation
+#: model_terms:ir.ui.view,arch_db:deltatech_service_equipment.view_service_equi_operation_form
+msgid "Service Equipment Operation"
+msgstr "Operație echipament service"
+
+#. module: deltatech_service_equipment
+#: model:ir.model,name:deltatech_service_equipment.model_service_equipment_type
+msgid "Service Equipment Type"
+msgstr "Tip echipament"
+
+#. module: deltatech_service_equipment
+#: model:ir.model,name:deltatech_service_equipment.model_service_equipment_category
+msgid "Service Equipment category"
+msgstr "Categorie echipament service"
+
+#. module: deltatech_service_equipment
+#: model:ir.model.fields,field_description:deltatech_service_equipment.field_service_equipment__group_id
+msgid "Service Group"
+msgstr "Grup service"
+
+#. module: deltatech_service_equipment
+#: model:ir.model,name:deltatech_service_equipment.model_service_meter_category
+msgid "Service Meter Category"
+msgstr "Categorie contor"
+
+#. module: deltatech_service_equipment
+#: model:ir.model,name:deltatech_service_equipment.model_service_template_meter
+msgid "Service Template Meter"
+msgstr "Șablon contor service"
+
+#. module: deltatech_service_equipment
+#: model:ir.model,name:deltatech_service_equipment.model_service_consumption
+msgid "Service consumption"
+msgstr "Consum service"
+
+#. module: deltatech_service_equipment
+#: model:ir.model,name:deltatech_service_equipment.model_service_history
+msgid "ServiceHistory"
+msgstr "Istoric service"
+
+#. module: deltatech_service_equipment
+#. odoo-python
+#: code:addons/deltatech_service_equipment/models/service_agreement.py:0
+msgid "Services Equipment"
+msgstr "Echipamente serice"
+
+#. module: deltatech_service_equipment
+#: model:ir.model.fields,field_description:deltatech_service_equipment.field_service_equipment__start_date
+msgid "Start Date"
+msgstr "Dată start"
+
+#. module: deltatech_service_equipment
+#: model:ir.model.fields,field_description:deltatech_service_equipment.field_service_equipment__state
+msgid "Status"
+msgstr "Stare"
+
+#. module: deltatech_service_equipment
+#: model_terms:ir.ui.view,arch_db:deltatech_service_equipment.view_service_equipment_filter
+msgid "Status agreement"
+msgstr "Stare contract"
+
+#. module: deltatech_service_equipment
+#: model:ir.model.fields,field_description:deltatech_service_equipment.field_service_equipment__agreement_state
+msgid "Status contract"
+msgstr "Stare contract"
+
+#. module: deltatech_service_equipment
+#: model:ir.model.fields,field_description:deltatech_service_equipment.field_service_equipment__location_id
+msgid "Stock Location"
+msgstr "Locație stoc"
+
+#. module: deltatech_service_equipment
+#: model:ir.model.fields,field_description:deltatech_service_equipment.field_service_equipment_category__template_meter_ids
+msgid "Template Meter"
+msgstr "Șablon contor"
+
+#. module: deltatech_service_equipment
+#. odoo-python
+#: code:addons/deltatech_service_equipment/wizard/service_billing_preparation.py:0
+msgid "The %s agreement does not have the meter readings made.\r\n"
+msgstr "Contractul %s nu are citirile de contor efectuate.\n"
+
+#. module: deltatech_service_equipment
+#: model:ir.model.fields,help:deltatech_service_equipment.field_service_equipment__address_id
+#: model:ir.model.fields,help:deltatech_service_equipment.field_service_meter_reading__address_id
+msgid "The address where the equipment is located"
+msgstr "Adresa la care se află echipamentul"
+
+#. module: deltatech_service_equipment
+#. odoo-python
+#: code:addons/deltatech_service_equipment/models/service_equipment.py:0
+msgid "The agreement %(agreement_name)s is in state %(agreement_state)s"
+msgstr "Contractul %(agreement_name)s este în starea %(agreement_state)s"
+
+#. module: deltatech_service_equipment
+#: model:ir.model.fields,field_description:deltatech_service_equipment.field_service_equipment__total_revenues
+msgid "Total Revenues"
+msgstr "Total venituri"
+
+#. module: deltatech_service_equipment
+#: model:ir.model.fields,field_description:deltatech_service_equipment.field_service_equipment__total_costs
+msgid "Total cost"
+msgstr "Cost total"
+
+#. module: deltatech_service_equipment
+#: model:ir.model.fields,field_description:deltatech_service_equipment.field_service_equipment__total_invoiced
+msgid "Total invoiced"
+msgstr "Total facturat"
+
+#. module: deltatech_service_equipment
+#: model_terms:ir.ui.view,arch_db:deltatech_service_equipment.service_history_form
+#: model_terms:ir.ui.view,arch_db:deltatech_service_equipment.service_history_search
+#: model_terms:ir.ui.view,arch_db:deltatech_service_equipment.service_history_tree
+msgid "Type"
+msgstr "Tip"
+
+#. module: deltatech_service_equipment
+#: model:ir.model.fields.selection,name:deltatech_service_equipment.selection__service_equipment__location_type__unavailable
+msgid "Unavailable"
+msgstr "Indisponibil"
+
+#. module: deltatech_service_equipment
+#. odoo-python
+#: code:addons/deltatech_service_equipment/wizard/service_equi_operation.py:0
+msgid "Uninstall"
+msgstr "Dezinstalează"
+
+#. module: deltatech_service_equipment
+#. odoo-python
+#: code:addons/deltatech_service_equipment/wizard/service_equi_operation.py:0
+msgid ""
+"Uninstalling equipment from %(partner_name)s, address %(address_name)s, emplacement %(emplacement)s.\r"
+"\r"
+"Meters: %(counters)s"
+msgstr ""
+"Dezinstalare echipament de la %(partner_name)s, adresă %(address_name)s, amplasament %(emplacement)s.\r\n"
+"Contori: %(counters)s"
+
+#. module: deltatech_service_equipment
+#: model:ir.model.fields.selection,name:deltatech_service_equipment.selection__service_equipment__readings_status__unmade
+msgid "Unmade"
+msgstr "Neefectuate"
+
+#. module: deltatech_service_equipment
+#: model:ir.actions.server,name:deltatech_service_equipment.action_update_meter_status
+msgid "Update Meter Status"
+msgstr "Actualizează starea contorilor"
+
+#. module: deltatech_service_equipment
+#: model:ir.actions.server,name:deltatech_service_equipment.action_update_totals
+msgid "Update Revenues"
+msgstr "Actualizează veniturile"
+
+#. module: deltatech_service_equipment
+#: model_terms:ir.ui.view,arch_db:deltatech_service_equipment.view_service_agreement_filter
+msgid "Without readings"
+msgstr "Fără citiri"
+
+#. module: deltatech_service_equipment
+#. odoo-python
+#: code:addons/deltatech_service_equipment/wizard/service_equi_operation.py:0
+#: model_terms:ir.ui.view,arch_db:deltatech_service_equipment.view_service_equi_operation_form
+msgid "You must bill consumption before uninstalling"
+msgstr "Trebuie să facturați consumul înainte de dezinstalare"
+
+#. module: deltatech_service_equipment
+#: model_terms:ir.ui.view,arch_db:deltatech_service_equipment.view_service_equi_operation_form
+msgid "close"
+msgstr "inchideți"
+
+#. module: deltatech_service_equipment
+#: model_terms:ir.ui.view,arch_db:deltatech_service_equipment.view_service_equi_operation_form
+msgid "or"
+msgstr "sau"
+
+#. module: deltatech_service_equipment
+#: model_terms:ir.ui.view,arch_db:deltatech_service_equipment.view_service_equipment_tree
+msgid "total"
+msgstr "total"
+
+#. module: deltatech_service_equipment
+#: model_terms:ir.ui.view,arch_db:deltatech_service_equipment.view_service_equi_operation_form
+msgid "x"
+msgstr "x"


### PR DESCRIPTION
## Ce face

Adaugă `i18n/ro.po` la `deltatech_service_equipment` — modulul nu avea folder `i18n`. **154/154 termeni traduși.**

Generat din exportul `.pot` **real** al modulului (`odoo-bin i18n export`): acoperă câmpurile fără `string=` explicit, valorile de selecție, help-urile, mesajele de eroare din Python și textele din view-uri/rapoarte.

## Terminologie

| EN | RO | de ce |
|---|---|---|
| Meter / Meters | Contor / Contori | ca în `deltatech_service_equipment_base` |
| Agreement | Contract | ca în restul suitei |
| Emplacement | Amplasament | |
| Readings | Citiri | |
| Backuped (stare echipament) | De rezervă | |
| In rental | În chirie | |
| Unmade / Done (stare citiri) | Neefectuate / Efectuate | corpusul propunea „Finalizat" pentru `Done`, greșit pentru citiri |

## Verificare

Încărcat efectiv într-o bază de test (`odoo-bin i18n loadlang -l ro_RO`) și citit din ORM cu `lang="ro_RO"`:

```
state: Stare -> {available: 'Disponibil', installing: 'În instalare', installed: 'Instalat',
                 inactive: 'Inactiv', backuped: 'De rezervă'}
location_type -> {stock: 'În stoc', rental: 'În chirie', customer: 'Client', unavailable: 'Indisponibil'}
readings_status: Stare citiri -> {unmade: 'Neefectuate', done: 'Efectuate'}
emplacement: Amplasament · agreement_id: Contract servicii · ean_code: Cod EAN
```

Mesajele cu `%(...)s` și cele cu `\r\n` intern (instalare/dezinstalare echipament) păstrează exact placeholder-ele și structura sursei — verificat cu `msgfmt --check-format`.

- `msgfmt --check --check-format` — 154 traduse, fără erori
- `scripts/i18n/po_normalize.py --check` — neschimbat
- pre-commit (`oca-checks-po`) — trecut

🤖 Generated with [Claude Code](https://claude.com/claude-code)