### PR TITLE
[IMP] deltatech_service_consumable: traducere RO

### DIFF
--- a/deltatech_service_consumable/i18n/ro.po
+++ b/deltatech_service_consumable/i18n/ro.po
@@ -1,0 +1,342 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* deltatech_service_consumable
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 19.0+e\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-07-30 07:52+0000\n"
+"PO-Revision-Date: 2026-07-30 07:52+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"Language: ro\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: deltatech_service_consumable
+#: model_terms:ir.ui.view,arch_db:deltatech_service_consumable.view_service_agreement_form
+#: model_terms:ir.ui.view,arch_db:deltatech_service_consumable.view_service_equipment_form
+msgid "<span class=\"o_stat_text\">Costs</span>"
+msgstr "<span class=\"o_stat_text\">Costuri</span>"
+
+#. module: deltatech_service_consumable
+#: model_terms:ir.ui.view,arch_db:deltatech_service_consumable.view_service_equipment_form
+msgid "<span class=\"o_stat_text\">Products delivered</span>"
+msgstr "<span class=\"o_stat_text\">Produse livrate</span>"
+
+#. module: deltatech_service_consumable
+#: model_terms:ir.ui.view,arch_db:deltatech_service_consumable.view_service_agreement_form
+msgid "<span class=\"o_stat_text\">Total percent</span>"
+msgstr "<span class=\"o_stat_text\">Procent total</span>"
+
+#. module: deltatech_service_consumable
+#: model:ir.model.fields,field_description:deltatech_service_consumable.field_service_equipment__permits_pickings
+msgid "Allows non-billable deliveries"
+msgstr "Permite livrări nefacturabile"
+
+#. module: deltatech_service_consumable
+#: model:ir.model.fields,field_description:deltatech_service_consumable.field_service_efficiency_report__amount
+msgid "Amount"
+msgstr "Valoare"
+
+#. module: deltatech_service_consumable
+#: model:ir.model.fields,field_description:deltatech_service_consumable.field_service_efficiency_report__categ_id
+msgid "Category"
+msgstr "Categorie"
+
+#. module: deltatech_service_consumable
+#: model:ir.model.fields,field_description:deltatech_service_consumable.field_service_efficiency_report__commercial_partner_id
+msgid "Commercial Entity"
+msgstr "Etitate comericlă"
+
+#. module: deltatech_service_consumable
+#: model:ir.model.fields,field_description:deltatech_service_consumable.field_service_efficiency_report__company_id
+msgid "Company"
+msgstr "Companie"
+
+#. module: deltatech_service_consumable
+#: model:ir.model.fields,field_description:deltatech_service_consumable.field_service_consumable_item__product_id
+#: model_terms:ir.ui.view,arch_db:deltatech_service_consumable.view_service_equipment_form
+msgid "Consumable"
+msgstr "Consumabil"
+
+#. module: deltatech_service_consumable
+#: model:ir.model,name:deltatech_service_consumable.model_service_consumable_item
+msgid "Consumable Item"
+msgstr "Articol consumabil"
+
+#. module: deltatech_service_consumable
+#: model:ir.model.fields,field_description:deltatech_service_consumable.field_service_equipment__consumable_item_ids
+#: model:ir.model.fields,field_description:deltatech_service_consumable.field_service_equipment_type__consumable_item_ids
+msgid "Consumables"
+msgstr "Consumabile"
+
+#. module: deltatech_service_consumable
+#: model:ir.model.fields,field_description:deltatech_service_consumable.field_service_equipment__consumables
+msgid "Consumables (text)"
+msgstr "Consumabile (text)"
+
+#. module: deltatech_service_consumable
+#: model:ir.model.fields,field_description:deltatech_service_consumable.field_service_efficiency_report__agreement_id
+msgid "Contract Services"
+msgstr "Contract servicii"
+
+#. module: deltatech_service_consumable
+#: model_terms:ir.ui.view,arch_db:deltatech_service_consumable.view_service_agreement_form
+#: model_terms:ir.ui.view,arch_db:deltatech_service_consumable.view_service_equipment_form
+msgid "Costs"
+msgstr "Costuri"
+
+#. module: deltatech_service_consumable
+#: model:ir.model.fields,field_description:deltatech_service_consumable.field_service_consumable_item__create_uid
+#: model:ir.model.fields,field_description:deltatech_service_consumable.field_service_efficiency_report__create_uid
+msgid "Created by"
+msgstr "Creat de"
+
+#. module: deltatech_service_consumable
+#: model:ir.model.fields,field_description:deltatech_service_consumable.field_service_consumable_item__create_date
+#: model:ir.model.fields,field_description:deltatech_service_consumable.field_service_efficiency_report__create_date
+msgid "Created on"
+msgstr "Creat pe"
+
+#. module: deltatech_service_consumable
+#: model:ir.model.fields,field_description:deltatech_service_consumable.field_service_efficiency_report__date
+msgid "Date"
+msgstr "Data"
+
+#. module: deltatech_service_consumable
+#. odoo-python
+#: code:addons/deltatech_service_consumable/models/service_agreement.py:0
+#: code:addons/deltatech_service_consumable/models/service_equipment.py:0
+#: model_terms:ir.ui.view,arch_db:deltatech_service_consumable.view_service_equipment_form
+msgid "Delivery for service"
+msgstr "Aviz service"
+
+#. module: deltatech_service_consumable
+#: model:ir.model.fields,field_description:deltatech_service_consumable.field_account_move__display_name
+#: model:ir.model.fields,field_description:deltatech_service_consumable.field_service_agreement__display_name
+#: model:ir.model.fields,field_description:deltatech_service_consumable.field_service_consumable_item__display_name
+#: model:ir.model.fields,field_description:deltatech_service_consumable.field_service_efficiency_report__display_name
+#: model:ir.model.fields,field_description:deltatech_service_consumable.field_service_equipment__display_name
+#: model:ir.model.fields,field_description:deltatech_service_consumable.field_service_equipment_type__display_name
+#: model:ir.model.fields,field_description:deltatech_service_consumable.field_stock_picking__display_name
+msgid "Display Name"
+msgstr "Nume afișat"
+
+#. module: deltatech_service_consumable
+#: model:ir.model.fields,field_description:deltatech_service_consumable.field_service_efficiency_report__equipment_id
+#: model:ir.model.fields,field_description:deltatech_service_consumable.field_stock_picking__equipment_id
+msgid "Equipment"
+msgstr "Echipament"
+
+#. module: deltatech_service_consumable
+#: model:ir.model.fields,field_description:deltatech_service_consumable.field_service_consumable_item__equipment_id
+msgid "Equipment (view)"
+msgstr "Echipament (vizualizare)"
+
+#. module: deltatech_service_consumable
+#: model:ir.model.fields,field_description:deltatech_service_consumable.field_service_consumable_item__colors
+msgid "HTML Colors Index"
+msgstr "Index culori HTML"
+
+#. module: deltatech_service_consumable
+#: model:ir.model.fields,field_description:deltatech_service_consumable.field_account_move__id
+#: model:ir.model.fields,field_description:deltatech_service_consumable.field_service_agreement__id
+#: model:ir.model.fields,field_description:deltatech_service_consumable.field_service_consumable_item__id
+#: model:ir.model.fields,field_description:deltatech_service_consumable.field_service_efficiency_report__id
+#: model:ir.model.fields,field_description:deltatech_service_consumable.field_service_equipment__id
+#: model:ir.model.fields,field_description:deltatech_service_consumable.field_service_equipment_type__id
+#: model:ir.model.fields,field_description:deltatech_service_consumable.field_stock_picking__id
+msgid "ID"
+msgstr "ID"
+
+#. module: deltatech_service_consumable
+#: model:ir.model,name:deltatech_service_consumable.model_account_move
+msgid "Journal Entry"
+msgstr "Notă contabilă"
+
+#. module: deltatech_service_consumable
+#: model:ir.model.fields,field_description:deltatech_service_consumable.field_service_consumable_item__write_uid
+#: model:ir.model.fields,field_description:deltatech_service_consumable.field_service_efficiency_report__write_uid
+msgid "Last Updated by"
+msgstr "Ultima actualizare de"
+
+#. module: deltatech_service_consumable
+#: model:ir.model.fields,field_description:deltatech_service_consumable.field_service_consumable_item__write_date
+#: model:ir.model.fields,field_description:deltatech_service_consumable.field_service_efficiency_report__write_date
+msgid "Last Updated on"
+msgstr "Ultima actualizare pe"
+
+#. module: deltatech_service_consumable
+#: model:ir.model.fields,field_description:deltatech_service_consumable.field_service_efficiency_report__location_id
+msgid "Location"
+msgstr "Locație"
+
+#. module: deltatech_service_consumable
+#: model:ir.model.fields,field_description:deltatech_service_consumable.field_service_efficiency_report__location_dest_id
+msgid "Location Destination"
+msgstr "Locație destinație"
+
+#. module: deltatech_service_consumable
+#: model:ir.model.fields,help:deltatech_service_consumable.field_service_consumable_item__max_qty
+msgid "Maximum Quantity allowed"
+msgstr "Cantitatea maximă permisă"
+
+#. module: deltatech_service_consumable
+#: model:ir.model.fields,field_description:deltatech_service_consumable.field_service_consumable_item__name
+msgid "Name"
+msgstr "Nume"
+
+#. module: deltatech_service_consumable
+#: model:ir.model.fields,field_description:deltatech_service_consumable.field_service_efficiency_report__partner_id
+msgid "Partner"
+msgstr "Partener"
+
+#. module: deltatech_service_consumable
+#: model:ir.model.fields,field_description:deltatech_service_consumable.field_service_efficiency_report__picking_id
+msgid "Picking"
+msgstr "Ridicare"
+
+#. module: deltatech_service_consumable
+#: model:ir.model.fields,field_description:deltatech_service_consumable.field_service_efficiency_report__picking_type_id
+msgid "Picking Type"
+msgstr "Tip ridicare"
+
+#. module: deltatech_service_consumable
+#: model:ir.model.fields,field_description:deltatech_service_consumable.field_service_efficiency_report__picking_type_code
+msgid "Picking Type Code"
+msgstr "Cod operație"
+
+#. module: deltatech_service_consumable
+#. odoo-python
+#: code:addons/deltatech_service_consumable/models/service_consumable.py:0
+#: code:addons/deltatech_service_consumable/models/service_equipment.py:0
+#: code:addons/deltatech_service_consumable/models/stock_picking.py:0
+msgid "Please define the picking type for service."
+msgstr "Definiți tipul de operație pentru service."
+
+#. module: deltatech_service_consumable
+#: model:ir.model.fields,field_description:deltatech_service_consumable.field_service_efficiency_report__price
+msgid "Price Unit"
+msgstr "Preț"
+
+#. module: deltatech_service_consumable
+#: model:ir.model.fields,field_description:deltatech_service_consumable.field_service_efficiency_report__product_id
+msgid "Product"
+msgstr "Produs"
+
+#. module: deltatech_service_consumable
+#: model:ir.model.fields,field_description:deltatech_service_consumable.field_service_consumable_item__quantity
+#: model:ir.model.fields,field_description:deltatech_service_consumable.field_service_efficiency_report__product_qty
+#: model_terms:ir.ui.view,arch_db:deltatech_service_consumable.view_service_equipment_form
+msgid "Quantity"
+msgstr "Cantitate"
+
+#. module: deltatech_service_consumable
+#: model:ir.model.fields,field_description:deltatech_service_consumable.field_service_consumable_item__max_qty
+msgid "Quantity Max"
+msgstr "Cantitate maximă"
+
+#. module: deltatech_service_consumable
+#: model_terms:ir.ui.view,arch_db:deltatech_service_consumable.view_picking_form
+msgid "Service"
+msgstr "Serviciu"
+
+#. module: deltatech_service_consumable
+#: model:ir.model,name:deltatech_service_consumable.model_service_agreement
+#: model:ir.model.fields,field_description:deltatech_service_consumable.field_stock_picking__agreement_id
+msgid "Service Agreement"
+msgstr "Contract"
+
+#. module: deltatech_service_consumable
+#: model:ir.model,name:deltatech_service_consumable.model_service_equipment
+msgid "Service Equipment"
+msgstr "Echipament"
+
+#. module: deltatech_service_consumable
+#: model:ir.model,name:deltatech_service_consumable.model_service_equipment_type
+msgid "Service Equipment Type"
+msgstr "Tip echipament"
+
+#. module: deltatech_service_consumable
+#: model:ir.model,name:deltatech_service_consumable.model_service_efficiency_report
+msgid "ServiceEfficiencyReport"
+msgstr "Raport eficiență service"
+
+#. module: deltatech_service_consumable
+#: model:ir.model.fields,help:deltatech_service_consumable.field_service_consumable_item__equipment_id
+msgid "Set when this consumable is rendered under an Equipment form."
+msgstr ""
+"Se setează când acest consumabil este afișat în formularul unui echipament."
+
+#. module: deltatech_service_consumable
+#: model:ir.model.fields,field_description:deltatech_service_consumable.field_service_consumable_item__shelf_life
+#: model:ir.model.fields,field_description:deltatech_service_consumable.field_service_efficiency_report__shelf_life
+msgid "Shelf Life"
+msgstr "Valabilitate"
+
+#. module: deltatech_service_consumable
+#: model:ir.model.fields,field_description:deltatech_service_consumable.field_service_consumable_item__uom_shelf_life
+msgid "Shelf Life UoM"
+msgstr "UM valabilitate"
+
+#. module: deltatech_service_consumable
+#. odoo-python
+#: code:addons/deltatech_service_consumable/models/service_consumable.py:0
+#: code:addons/deltatech_service_consumable/models/service_equipment.py:0
+msgid "Stock Settings"
+msgstr "Setări stoc"
+
+#. module: deltatech_service_consumable
+#: model:ir.model.fields,field_description:deltatech_service_consumable.field_service_agreement__total_costs
+msgid "Total Cost"
+msgstr "Cost total"
+
+#. module: deltatech_service_consumable
+#: model:ir.model.fields,field_description:deltatech_service_consumable.field_service_agreement__total_percent
+#: model_terms:ir.ui.view,arch_db:deltatech_service_consumable.view_service_agreement_form
+msgid "Total percent"
+msgstr "Procent total"
+
+#. module: deltatech_service_consumable
+#: model:ir.model,name:deltatech_service_consumable.model_stock_picking
+msgid "Transfer"
+msgstr "Transfer"
+
+#. module: deltatech_service_consumable
+#: model:ir.model.fields,field_description:deltatech_service_consumable.field_service_consumable_item__type_id
+msgid "Type"
+msgstr "Tip"
+
+#. module: deltatech_service_consumable
+#: model:ir.model.fields,field_description:deltatech_service_consumable.field_service_efficiency_report__product_uom
+msgid "Unit of Measure"
+msgstr "Unitatea de măsură"
+
+#. module: deltatech_service_consumable
+#: model:ir.model.fields,field_description:deltatech_service_consumable.field_service_efficiency_report__uom_usage
+msgid "Unit of Measure Usage"
+msgstr "Unitate de măsură consum"
+
+#. module: deltatech_service_consumable
+#: model:ir.model.fields,help:deltatech_service_consumable.field_service_consumable_item__uom_shelf_life
+msgid "Unit of Measure for Shelf Life"
+msgstr "Unitate de masura pentru valabilitate"
+
+#. module: deltatech_service_consumable
+#: model:ir.model.fields,help:deltatech_service_consumable.field_service_efficiency_report__uom_usage
+msgid "Unit of Measure for Usage"
+msgstr "Unitatea de măsură pentru consum"
+
+#. module: deltatech_service_consumable
+#: model:ir.model.fields,field_description:deltatech_service_consumable.field_service_efficiency_report__usage
+msgid "Usage"
+msgstr "Utilizare"
+
+#. module: deltatech_service_consumable
+#: model:ir.model.fields,field_description:deltatech_service_consumable.field_service_efficiency_report__product_weight
+msgid "Weight"
+msgstr "Greutate"


### PR DESCRIPTION
## Ce face

Adaugă `i18n/ro.po` la `deltatech_service_consumable` — modulul nu avea folder `i18n`. **58/58 termeni traduși.**

Generat din exportul `.pot` real al modulului (`odoo-bin i18n export`).

## Terminologie

| EN | RO |
|---|---|
| Consumable / Consumable Item | Consumabil / Articol consumabil |
| Contract Services | Contract servicii |
| Shelf Life UoM | UM valabilitate |
| Quantity Max / Maximum Quantity allowed | Cantitate maximă / Cantitatea maximă permisă |
| picking type for service | tip de operație pentru service |

`Shelf Life` → „valabilitate" și `Operation Type` → „tip operație" urmează traducerile deja folosite în corpusul RO existent.

## Verificare

- `msgfmt --check --check-format` — 58 traduse, fără erori
- `scripts/i18n/po_normalize.py --check` — neschimbat
- pre-commit (`oca-checks-po`) — trecut
- limba încărcată efectiv pe o bază de test (`i18n loadlang -l ro_RO`), fără erori

🤖 Generated with [Claude Code](https://claude.com/claude-code)