### PR TITLE
[IMP] deltatech_service_task: traducere RO

### DIFF
--- a/deltatech_service_task/i18n/ro.po
+++ b/deltatech_service_task/i18n/ro.po
@@ -1,0 +1,328 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* deltatech_service_task
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 19.0+e\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-07-30 07:52+0000\n"
+"PO-Revision-Date: 2026-07-30 07:52+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"Language: ro\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: deltatech_service_task
+#: model:ir.actions.report,print_report_name:deltatech_service_task.action_report_project_task_service
+msgid "'Service Equipament Report - %s' % (object.name)"
+msgstr ""
+
+#. module: deltatech_service_task
+#: model_terms:ir.ui.view,arch_db:deltatech_service_task.report_project_task_service_contents
+msgid "<strong>Customer:</strong>"
+msgstr "<strong>Client:</strong>"
+
+#. module: deltatech_service_task
+#: model_terms:ir.ui.view,arch_db:deltatech_service_task.report_project_task_service_contents
+msgid "<strong>Equipment:</strong>"
+msgstr "<strong>Echipament:</strong>"
+
+#. module: deltatech_service_task
+#: model_terms:ir.ui.view,arch_db:deltatech_service_task.report_project_task_service_contents
+msgid "<strong>Location:</strong>"
+msgstr "<strong>Locație:</strong>"
+
+#. module: deltatech_service_task
+#: model_terms:ir.ui.view,arch_db:deltatech_service_task.view_task_form2_inherited
+msgid "Cantitate:"
+msgstr "Cantitate:"
+
+#. module: deltatech_service_task
+#: model:ir.model.fields,field_description:deltatech_service_task.field_project_task_check__check_id
+msgid "Check"
+msgstr "Verificare"
+
+#. module: deltatech_service_task
+#. odoo-python
+#: code:addons/deltatech_service_task/models/service_equipment.py:0
+msgid "Check History"
+msgstr "Istoric verificări"
+
+#. module: deltatech_service_task
+#: model:ir.model.fields,field_description:deltatech_service_task.field_service_equipment__check_history_count
+msgid "Check History Count"
+msgstr "Număr verificări în istoric"
+
+#. module: deltatech_service_task
+#: model_terms:ir.ui.view,arch_db:deltatech_service_task.report_project_task_service_contents
+msgid "Check Item"
+msgstr "Element verificat"
+
+#. module: deltatech_service_task
+#: model:ir.model.fields,field_description:deltatech_service_task.field_project_task__check_ids
+#: model_terms:ir.ui.view,arch_db:deltatech_service_task.report_project_task_service_contents
+#: model_terms:ir.ui.view,arch_db:deltatech_service_task.view_service_equipment_form_inherited
+#: model_terms:ir.ui.view,arch_db:deltatech_service_task.view_task_form2_inherited
+msgid "Checks"
+msgstr "Controale"
+
+#. module: deltatech_service_task
+#: model:ir.model.fields,field_description:deltatech_service_task.field_project_task_check__create_uid
+#: model:ir.model.fields,field_description:deltatech_service_task.field_project_task_measurement__create_uid
+#: model:ir.model.fields,field_description:deltatech_service_task.field_project_task_part__create_uid
+msgid "Created by"
+msgstr "Creat de"
+
+#. module: deltatech_service_task
+#: model:ir.model.fields,field_description:deltatech_service_task.field_project_task_check__create_date
+#: model:ir.model.fields,field_description:deltatech_service_task.field_project_task_measurement__create_date
+#: model:ir.model.fields,field_description:deltatech_service_task.field_project_task_part__create_date
+msgid "Created on"
+msgstr "Creat pe"
+
+#. module: deltatech_service_task
+#: model:ir.model.fields,field_description:deltatech_service_task.field_project_task_measurement__date_measurement
+msgid "Data Măsurătorii"
+msgstr "Data Măsurătorii"
+
+#. module: deltatech_service_task
+#: model:ir.model.fields,field_description:deltatech_service_task.field_project_task__display_name
+#: model:ir.model.fields,field_description:deltatech_service_task.field_project_task_check__display_name
+#: model:ir.model.fields,field_description:deltatech_service_task.field_project_task_measurement__display_name
+#: model:ir.model.fields,field_description:deltatech_service_task.field_project_task_part__display_name
+#: model:ir.model.fields,field_description:deltatech_service_task.field_service_equipment__display_name
+msgid "Display Name"
+msgstr "Nume afișat"
+
+#. module: deltatech_service_task
+#: model:ir.model.fields,field_description:deltatech_service_task.field_project_task__equipment_type_summary
+msgid "Equipment Type Summary"
+msgstr "Sumar tip echipament"
+
+#. module: deltatech_service_task
+#: model:ir.model.fields,field_description:deltatech_service_task.field_project_task__service_location_id
+#: model_terms:ir.ui.view,arch_db:deltatech_service_task.view_task_search_form_inherited
+msgid "Functional Location"
+msgstr "Loc Funcțional"
+
+#. module: deltatech_service_task
+#: model:ir.model.fields,field_description:deltatech_service_task.field_project_task__id
+#: model:ir.model.fields,field_description:deltatech_service_task.field_project_task_check__id
+#: model:ir.model.fields,field_description:deltatech_service_task.field_project_task_measurement__id
+#: model:ir.model.fields,field_description:deltatech_service_task.field_project_task_part__id
+#: model:ir.model.fields,field_description:deltatech_service_task.field_service_equipment__id
+msgid "ID"
+msgstr "ID"
+
+#. module: deltatech_service_task
+#: model:ir.model.fields,field_description:deltatech_service_task.field_project_task_check__is_ok
+#: model:ir.model.fields,field_description:deltatech_service_task.field_project_task_part__is_ok
+msgid "Is OK"
+msgstr "Este OK"
+
+#. module: deltatech_service_task
+#: model:ir.model.fields,field_description:deltatech_service_task.field_project_task_check__write_uid
+#: model:ir.model.fields,field_description:deltatech_service_task.field_project_task_measurement__write_uid
+#: model:ir.model.fields,field_description:deltatech_service_task.field_project_task_part__write_uid
+msgid "Last Updated by"
+msgstr "Ultima actualizare de"
+
+#. module: deltatech_service_task
+#: model:ir.model.fields,field_description:deltatech_service_task.field_project_task_check__write_date
+#: model:ir.model.fields,field_description:deltatech_service_task.field_project_task_measurement__write_date
+#: model:ir.model.fields,field_description:deltatech_service_task.field_project_task_part__write_date
+msgid "Last Updated on"
+msgstr "Ultima actualizare pe"
+
+#. module: deltatech_service_task
+#: model:ir.model.fields,field_description:deltatech_service_task.field_project_task_measurement__measurement_id
+#: model_terms:ir.ui.view,arch_db:deltatech_service_task.report_project_task_service_contents
+msgid "Measurement"
+msgstr "Măsurătoare"
+
+#. module: deltatech_service_task
+#. odoo-python
+#: code:addons/deltatech_service_task/models/service_equipment.py:0
+msgid "Measurement History"
+msgstr "Istoric măsurători"
+
+#. module: deltatech_service_task
+#: model:ir.model.fields,field_description:deltatech_service_task.field_service_equipment__measurement_history_count
+msgid "Measurement History Count"
+msgstr "Număr măsurători în istoric"
+
+#. module: deltatech_service_task
+#: model:ir.model.fields,field_description:deltatech_service_task.field_project_task__measurement_ids
+#: model_terms:ir.ui.view,arch_db:deltatech_service_task.report_project_task_service_contents
+#: model_terms:ir.ui.view,arch_db:deltatech_service_task.view_service_equipment_form_inherited
+#: model_terms:ir.ui.view,arch_db:deltatech_service_task.view_task_form2_inherited
+msgid "Measurements"
+msgstr "Măsurători"
+
+#. module: deltatech_service_task
+#: model_terms:ir.ui.view,arch_db:deltatech_service_task.report_project_task_service_contents
+msgid "Not OK"
+msgstr "Nu este OK"
+
+#. module: deltatech_service_task
+#: model:ir.model.fields,field_description:deltatech_service_task.field_project_task_check__note
+#: model:ir.model.fields,field_description:deltatech_service_task.field_project_task_measurement__note
+#: model:ir.model.fields,field_description:deltatech_service_task.field_project_task_part__note
+#: model_terms:ir.ui.view,arch_db:deltatech_service_task.report_project_task_service_contents
+msgid "Note"
+msgstr "Notă"
+
+#. module: deltatech_service_task
+#: model_terms:ir.ui.view,arch_db:deltatech_service_task.report_project_task_service_contents
+msgid "OK"
+msgstr "OK"
+
+#. module: deltatech_service_task
+#: model:ir.model.fields,field_description:deltatech_service_task.field_project_task_part__part_id
+#: model_terms:ir.ui.view,arch_db:deltatech_service_task.report_project_task_service_contents
+msgid "Part"
+msgstr "Piesă"
+
+#. module: deltatech_service_task
+#. odoo-python
+#: code:addons/deltatech_service_task/models/service_equipment.py:0
+msgid "Part History"
+msgstr "Istoric piese"
+
+#. module: deltatech_service_task
+#: model:ir.model.fields,field_description:deltatech_service_task.field_service_equipment__part_history_count
+msgid "Part History Count"
+msgstr "Număr piese în istoric"
+
+#. module: deltatech_service_task
+#: model:ir.model.fields,field_description:deltatech_service_task.field_project_task__part_ids
+#: model_terms:ir.ui.view,arch_db:deltatech_service_task.report_project_task_service_contents
+#: model_terms:ir.ui.view,arch_db:deltatech_service_task.view_service_equipment_form_inherited
+#: model_terms:ir.ui.view,arch_db:deltatech_service_task.view_task_form2_inherited
+msgid "Parts"
+msgstr "Părți"
+
+#. module: deltatech_service_task
+#: model:ir.model,name:deltatech_service_task.model_project_task_check
+msgid "Project Task Check"
+msgstr "Verificare sarcină proiect"
+
+#. module: deltatech_service_task
+#: model:ir.model,name:deltatech_service_task.model_project_task_measurement
+msgid "Project Task Measurement"
+msgstr "Măsurătoare sarcină proiect"
+
+#. module: deltatech_service_task
+#: model:ir.model,name:deltatech_service_task.model_project_task_part
+msgid "Project Task Part"
+msgstr "Piesă sarcină proiect"
+
+#. module: deltatech_service_task
+#: model:ir.model.fields,field_description:deltatech_service_task.field_project_task_part__quantity
+#: model_terms:ir.ui.view,arch_db:deltatech_service_task.report_project_task_service_contents
+msgid "Quantity"
+msgstr "Cantitate"
+
+#. module: deltatech_service_task
+#: model:ir.model.fields,field_description:deltatech_service_task.field_project_task_check__sequence
+#: model:ir.model.fields,field_description:deltatech_service_task.field_project_task_measurement__sequence
+#: model:ir.model.fields,field_description:deltatech_service_task.field_project_task_part__sequence
+msgid "Sequence"
+msgstr "Secvență"
+
+#. module: deltatech_service_task
+#: model:ir.actions.report,name:deltatech_service_task.action_report_project_task_service
+msgid "Service Equipament Report"
+msgstr "Raport echipament service"
+
+#. module: deltatech_service_task
+#: model:ir.model,name:deltatech_service_task.model_service_equipment
+#: model:ir.model.fields,field_description:deltatech_service_task.field_project_task__service_equipment_id
+#: model:ir.model.fields,field_description:deltatech_service_task.field_project_task_check__equipment_id
+#: model:ir.model.fields,field_description:deltatech_service_task.field_project_task_measurement__equipment_id
+#: model:ir.model.fields,field_description:deltatech_service_task.field_project_task_part__equipment_id
+#: model_terms:ir.ui.view,arch_db:deltatech_service_task.view_task_search_form_inherited
+msgid "Service Equipment"
+msgstr "Echipament"
+
+#. module: deltatech_service_task
+#: model_terms:ir.ui.view,arch_db:deltatech_service_task.report_project_task_service_template
+msgid "Service Report:"
+msgstr "Raport service:"
+
+#. module: deltatech_service_task
+#: model_terms:ir.ui.view,arch_db:deltatech_service_task.report_project_task_service_contents
+msgid "Status"
+msgstr "Stare"
+
+#. module: deltatech_service_task
+#: model:ir.model,name:deltatech_service_task.model_project_task
+#: model:ir.model.fields,field_description:deltatech_service_task.field_project_task_check__task_id
+#: model:ir.model.fields,field_description:deltatech_service_task.field_project_task_measurement__task_id
+#: model:ir.model.fields,field_description:deltatech_service_task.field_project_task_part__task_id
+msgid "Task"
+msgstr "Sarcină"
+
+#. module: deltatech_service_task
+#: model:ir.model.fields,field_description:deltatech_service_task.field_service_equipment__task_count
+msgid "Task Count"
+msgstr "Număr sarcini"
+
+#. module: deltatech_service_task
+#: model_terms:ir.ui.view,arch_db:deltatech_service_task.view_service_equipment_form_inherited
+msgid "Tasks"
+msgstr "Sarcini"
+
+#. module: deltatech_service_task
+#: model:ir.model.fields,field_description:deltatech_service_task.field_project_task__employee_ids
+msgid "Team"
+msgstr "Echipă"
+
+#. module: deltatech_service_task
+#: model_terms:ir.ui.view,arch_db:deltatech_service_task.report_project_task_service_contents
+msgid "Unit"
+msgstr "Unitate de măsură"
+
+#. module: deltatech_service_task
+#: model:ir.model.fields,field_description:deltatech_service_task.field_project_task_measurement__uom_id
+msgid "Unit of Measure"
+msgstr "Unitatea de măsură"
+
+#. module: deltatech_service_task
+#: model:ir.model.fields,help:deltatech_service_task.field_project_task__display_name
+msgid ""
+"Use these keywords in the title to set new tasks:\n"
+"\n"
+"            #tags Set tags on the task\n"
+"            @user Assign the task to a user\n"
+"            ! Set the task a medium priority\n"
+"            !! Set the task a high priority\n"
+"            !!! Set the task a urgent priority\n"
+"\n"
+"            Make sure to use the right format and order e.g. Improve the configuration screen #feature #v16 @Mitchell !"
+msgstr ""
+"Utilizați aceste cuvinte cheie în titlu pentru a seta sarcini noi:\n"
+"\n"
+"            #tags Setează etichete pe sarcină\n"
+"            @user Atribuie sarcina unui utilizator\n"
+"            ! Setează o prioritate medie sarcinii\n"
+"            !! Setează o prioritate ridicată sarcinii\n"
+"            !!! Setează o prioritate urgentă sarcinii\n"
+"\n"
+"            Asigurați-vă că utilizați formatul și ordinea corectă, de ex. Îmbunătățiți ecranul de configurare #feature #v16 @Mitchell !"
+
+#. module: deltatech_service_task
+#: model:ir.model.fields,field_description:deltatech_service_task.field_project_task_measurement__value
+#: model_terms:ir.ui.view,arch_db:deltatech_service_task.report_project_task_service_contents
+msgid "Value"
+msgstr "Valoare"
+
+#. module: deltatech_service_task
+#. odoo-python
+#: code:addons/deltatech_service_task/models/service_equipment.py:0
+msgid "equipment_id"
+msgstr ""


### PR DESCRIPTION
## Ce face

Adaugă `i18n/ro.po` la `deltatech_service_task` — modulul nu avea folder `i18n`. **47 din 49 termeni traduși.**

Generat din exportul `.pot` real al modulului (`odoo-bin i18n export`).

Cele două rămase goale sunt intenționat netraduse:
- `'Service Equipament Report - %s' % (object.name)` — expresie Python din `print_report_name`, nu text de interfață
- `equipment_id` — identificator tehnic prins de extractor

## Terminologie

| EN | RO |
|---|---|
| Part / Part History | Piesă / Istoric piese |
| Check / Check History | Verificare / Istoric verificări |
| Measurement / Measurements | Măsurătoare / Măsurători |
| Check Item | Element verificat |
| Is OK / Not OK | Este OK / Nu este OK |

`Check` este substantiv aici (`project.task.check.check_id`), nu buton — corpusul propunea „Verifică".

Modulul are câteva stringuri scrise direct în română în cod (`Cantitate:`, `Data Măsurătorii`); pentru ele traducerea este identitatea. Rămâne și typo-ul din sursă (`Equipament`) în `msgid` — l-am păstrat, ca `msgid`-ul să se potrivească.

Help-ul cu cuvintele cheie pentru titlul sarcinii reia traducerea oficială din `project`, adaptată la varianta de `msgid` a modulului (fără linia `30h`).

## Verificare

- `msgfmt --check --check-format` — 47 traduse, 2 netraduse (cele de mai sus), fără erori
- `scripts/i18n/po_normalize.py --check` — neschimbat
- pre-commit (`oca-checks-po`) — trecut
- verificat în ORM cu `lang="ro_RO"`: `check_id: Verificare`, `is_ok: Este OK`

🤖 Generated with [Claude Code](https://claude.com/claude-code)