### PR TITLE
[DOC] Noutăți 19.0 per modul + index de suită

### DIFF
--- a/NOUTATI_19.md
+++ b/NOUTATI_19.md
@@ -1,0 +1,14 @@
+# Ce e nou în 19.0 — Suita deltatech_service — service și mentenanță
+
+Sinteză a noutăților față de versiunea 18.0, pe 3 module. Detaliile fiecărui modul sunt în
+`<modul>/readme/NOUTATI_19.md`.
+
+## Module cu funcționalități noi față de 18.0 (3)
+
+- **Grupe de categorii pentru echipamente** (`deltatech_category_group_equipment`) — Căutare mai bună în lista de
+  echipamente — filtre și grupări suplimentare pe ecranul de echipamente, cu denumiri clarificate, astfel încât un
+  tehnician găsește mai….
+- **Acorduri de service** (`deltatech_service_agreement`) — Acordurile pot fi consultate și de utilizatorii fără rol
+  avansat (inclusiv din zona publică/portal), fără să fie nevoie să li se acorde drepturi suplimentare pe modelele….
+- **Consumabile la service** (`deltatech_service_consumable`) — Costul total al consumabilelor se calculează mai rapid,
+  iar raportul de eficiență a serviciilor filtrează corect pe unități de măsură — cifrele de pe intervenții rămân….

--- a/NOUTATI_19.md
+++ b/NOUTATI_19.md
@@ -12,3 +12,12 @@ Sinteză a noutăților față de versiunea 18.0, pe 3 module. Detaliile fiecăr
   avansat (inclusiv din zona publică/portal), fără să fie nevoie să li se acorde drepturi suplimentare pe modelele….
 - **Consumabile la service** (`deltatech_service_consumable`) — Costul total al consumabilelor se calculează mai rapid,
   iar raportul de eficiență a serviciilor filtrează corect pe unități de măsură — cifrele de pe intervenții rămân….
+
+## Module de pe 18.0 fără corespondent în 19.0 (2)
+
+Pentru completitudine, în sens invers: module care există pe ramura 18.0 și nu au (încă) un echivalent pe 19.0.
+
+**Nemigrate încă (2)** — fără semnal de retragere; ultima modificare pe 18.0 în paranteze:
+
+- `deltatech_service_maintenance_agreement` — Deltatech Services Maintenance Agreement (2025-11)
+- `deltatech_service_maintenance_plan` — Deltatech Services Maintenance Plan (2025-11)

--- a/deltatech_category_group_equipment/readme/NOUTATI_19.md
+++ b/deltatech_category_group_equipment/readme/NOUTATI_19.md
@@ -1,0 +1,4 @@
+# Ce e nou în 19.0 — Grupe de categorii pentru echipamente
+
+## Ce e nou față de 18.0
+- **Căutare mai bună în lista de echipamente** — filtre și grupări suplimentare pe ecranul de echipamente, cu denumiri clarificate, astfel încât un tehnician găsește mai repede echipamentele unei categorii.

--- a/deltatech_service_agreement/readme/NOUTATI_19.md
+++ b/deltatech_service_agreement/readme/NOUTATI_19.md
@@ -1,0 +1,4 @@
+# Ce e nou în 19.0 — Acorduri de service
+
+## Ce e nou față de 18.0
+- **Acordurile pot fi consultate și de utilizatorii fără rol avansat** (inclusiv din zona publică/portal), fără să fie nevoie să li se acorde drepturi suplimentare pe modelele conexe. Clientul își vede condițiile contractuale fără intervenția unui administrator.

--- a/deltatech_service_consumable/readme/NOUTATI_19.md
+++ b/deltatech_service_consumable/readme/NOUTATI_19.md
@@ -1,0 +1,5 @@
+# Ce e nou în 19.0 — Consumabile la service
+
+## Ce e nou față de 18.0
+- **Costul total al consumabilelor se calculează mai rapid**, iar raportul de eficiență a serviciilor filtrează corect pe unități de măsură — cifrele de pe intervenții rămân comparabile chiar și când produsele se consumă în unități diferite.
+- Manipularea mișcărilor de stoc a fost aliniată la modul standard din Odoo 19, ceea ce elimină diferențele de comportament când se lucrează cu colete/pachete.


### PR DESCRIPTION
Adaugă `readme/NOUTATI_19.md` pentru fiecare modul cu noutăți funcționale față de 18.0, scris pentru prezentare către client, plus indexul de suită `NOUTATI_19.md`.

**Cum au fost stabilite noutățile**
- Module prezente pe `origin/19.0` și absente pe `origin/18.0` → module noi.
- Pentru restul: commit-uri `[ADD]`/`[IMP]` de pe `origin/19.0` neajunse pe `origin/18.0`, cu echivalență pe **patch-id**, ca o modificare replayată la migrare cu alt SHA să nu apară drept noutate.
- Excluse: documentație, traduceri, teste, reformatări și commit-urile care ating toată suita (generator README, banere Apps Store).

Doar fișiere de documentație — niciun cod atins.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
