### PR TITLE
[DOC] Noutăți 19.0: șase module migrate, inventar actualizat

### DIFF
--- a/NOUTATI_19.md
+++ b/NOUTATI_19.md
@@ -17,7 +17,7 @@ Sinteză a noutăților față de versiunea 18.0, pe 3 module. Detaliile fiecăr
 
 Pentru completitudine, în sens invers: module care există pe ramura 18.0 și nu au (încă) un echivalent pe 19.0.
 
-**Nemigrate încă (2)** — fără semnal de retragere; ultima modificare pe 18.0 în paranteze:
+**Nemigrate încă (2)** — ultima modificare de cod în paranteze:
 
-- `deltatech_service_maintenance_agreement` — Deltatech Services Maintenance Agreement (2025-11)
-- `deltatech_service_maintenance_plan` — Deltatech Services Maintenance Plan (2025-11)
+- `deltatech_service_maintenance_agreement` — Deltatech Services Maintenance Agreement (2025-06)
+- `deltatech_service_maintenance_plan` — Deltatech Services Maintenance Plan (2025-08)


### PR DESCRIPTION
Actualizare a documentației de noutăți 19.0, după migrarea a șase module.

**Module migrate între timp** (primesc `readme/NOUTATI_19.md`): `deltatech_instastat_tax_risk`, `deltatech_payment_tbi_bank`, `deltatech_picking_split`, `deltatech_warranty`, `deltatech_website_sale_wishlist`. (`l10n_ro_einvoice_download` a ajuns în `l10n-romania`, depozit OCA — acolo nu adăugăm fișiere în convenția noastră.)

**Inventarul invers recalculat:** 100 → 94 module de pe 18.0 fără corespondent, 89 → 83 nemigrate.

Lista de nemigrate afișează acum **ultima modificare de cod**, nu ultima atingere — commiturile de întreținere în masă atingeau zeci de module fără schimbare funcțională și le făceau să pară active.

Doar fișiere de documentație.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
